### PR TITLE
Update examples / tests to use correct option names

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -7,7 +7,7 @@ You can change many options for how this extension works via
 
 .. code-block:: python
 
-  app.config[OPTION_NAME] = new_options
+  app.config[OPTION_NAME] = new_option_value
 
 Options:
 ~~~~~~~~~~~~~~~~
@@ -15,13 +15,17 @@ Options:
 ================================= =================================================
 ``JWT_TOKEN_ARGUMENT_NAME``        Where to look for a JWT in resolver argument
 ``JWT_ACCESS_TOKEN_EXPIRES``       How long an access token should live before
-                                   it expires. This takes a ``datetime.timedelta``,
-                                   and defaults to 15 minutes. Can be set to
-                                   ``False`` to disable expiration.
+                                   it expires. This takes a ``datetime.timedelta``
+                                   or an ``int``, and defaults to 15 minutes. Can
+                                   be set to ``False`` to disable expiration.
+                                   If this value is an ``int`` it will be parsed
+                                   as minutes.
 ``JWT_REFRESH_TOKEN_EXPIRES``      How long a refresh token should live before
-                                   it expires. This takes a ``datetime.timedelta``,
-                                   and defaults to 30 days. Can be set to
-                                   `False`` to disable expiration.
+                                   it expires. This takes a ``datetime.timedelta``
+                                   or an ``int``, and defaults to 30 days. Can
+                                   be set to ``False`` to disable expiration.
+                                   If this value is an ``int`` it will be parsed
+                                   as days.
 ``JWT_SECRET_KEY``                 The secret key needed for symmetric based signing
                                    algorithms, such as ``HS*``. If this is not set,
                                    we use the flask ``SECRET_KEY`` value instead.

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -74,7 +74,9 @@ class RefreshMutation(graphene.Mutation):
     @mutation_jwt_refresh_token_required
     def mutate(self, _):
         current_user = get_jwt_identity()
-        return RefreshMutation(new_token=create_access_token(identity=current_user))
+        return RefreshMutation(
+            new_token=create_access_token(identity=current_user),
+        )
 
 
 class Mutation(graphene.ObjectType):
@@ -94,7 +96,8 @@ class Query(graphene.ObjectType):
 schema = graphene.Schema(query=Query, mutation=Mutation)
 
 app.add_url_rule(
-    "/graphql", view_func=GraphQLView.as_view("graphql", schema=schema, graphiql=True)
+    "/graphql",
+    view_func=GraphQLView.as_view("graphql", schema=schema, graphiql=True),
 )
 
 if __name__ == "__main__":

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -17,8 +17,8 @@ app = Flask(__name__)
 auth = GraphQLAuth(app)
 
 app.config["JWT_SECRET_KEY"] = "something"  # change this!
-app.config["REFRESH_EXP_LENGTH"] = 30
-app.config["ACCESS_EXP_LENGTH"] = 10
+app.config["JWT_ACCESS_TOKEN_EXPIRES"] = 10  # 10 minutes
+app.config["JWT_REFRESH_TOKEN_EXPIRES"] = 30  # 30 days
 
 
 class MessageField(graphene.ObjectType):

--- a/examples/jwt_in_header.py
+++ b/examples/jwt_in_header.py
@@ -16,8 +16,8 @@ app = Flask(__name__)
 auth = GraphQLAuth(app)
 
 app.config["JWT_SECRET_KEY"] = "something"  # change this!
-app.config["REFRESH_EXP_LENGTH"] = 30
-app.config["ACCESS_EXP_LENGTH"] = 10
+app.config["JWT_ACCESS_TOKEN_EXPIRES"] = 10  # 10 minutes
+app.config["JWT_REFRESH_TOKEN_EXPIRES"] = 30  # 30 days
 
 
 class MessageField(graphene.ObjectType):

--- a/examples/jwt_in_header.py
+++ b/examples/jwt_in_header.py
@@ -73,7 +73,9 @@ class RefreshMutation(graphene.Mutation):
     @mutation_header_jwt_refresh_token_required
     def mutate(cls, _):
         current_user = get_jwt_identity()
-        return RefreshMutation(new_token=create_access_token(identity=current_user))
+        return RefreshMutation(
+            new_token=create_access_token(identity=current_user),
+        )
 
 
 class Mutation(graphene.ObjectType):
@@ -93,7 +95,8 @@ class Query(graphene.ObjectType):
 schema = graphene.Schema(query=Query, mutation=Mutation)
 
 app.add_url_rule(
-    "/graphql", view_func=GraphQLView.as_view("graphql", schema=schema, graphiql=True)
+    "/graphql",
+    view_func=GraphQLView.as_view("graphql", schema=schema, graphiql=True),
 )
 
 if __name__ == "__main__":

--- a/examples/user_claims.py
+++ b/examples/user_claims.py
@@ -17,8 +17,8 @@ app = Flask(__name__)
 auth = GraphQLAuth(app)
 
 app.config["JWT_SECRET_KEY"] = "something"  # change this!
-app.config["REFRESH_EXP_LENGTH"] = 30
-app.config["ACCESS_EXP_LENGTH"] = 10
+app.config["JWT_ACCESS_TOKEN_EXPIRES"] = 10  # 10 minutes
+app.config["JWT_REFRESH_TOKEN_EXPIRES"] = 30  # 30 days
 
 user_claims = {"message": "VERI TAS LUX MEA"}
 
@@ -47,8 +47,10 @@ class AuthMutation(graphene.Mutation):
     @classmethod
     def mutate(cls, _, info, username, password):
         return AuthMutation(
-            access_token=create_access_token(username, user_claims=user_claims),
-            refresh_token=create_refresh_token(username, user_claims=user_claims),
+            access_token=create_access_token(
+                username, user_claims=user_claims),
+            refresh_token=create_refresh_token(
+                username, user_claims=user_claims),
         )
 
 
@@ -74,7 +76,7 @@ class RefreshMutation(graphene.Mutation):
 
     @classmethod
     @mutation_jwt_refresh_token_required
-    def mutate(self, _, info):
+    def mutate(cls, _, info):
         current_user = get_jwt_identity()
         return RefreshMutation(
             new_token=create_access_token(

--- a/examples/user_claims.py
+++ b/examples/user_claims.py
@@ -48,9 +48,13 @@ class AuthMutation(graphene.Mutation):
     def mutate(cls, _, info, username, password):
         return AuthMutation(
             access_token=create_access_token(
-                username, user_claims=user_claims),
+                username,
+                user_claims=user_claims,
+            ),
             refresh_token=create_refresh_token(
-                username, user_claims=user_claims),
+                username,
+                user_claims=user_claims,
+            ),
         )
 
 
@@ -80,7 +84,8 @@ class RefreshMutation(graphene.Mutation):
         current_user = get_jwt_identity()
         return RefreshMutation(
             new_token=create_access_token(
-                identity=current_user, user_claims=user_claims
+                identity=current_user,
+                user_claims=user_claims,
             )
         )
 
@@ -93,7 +98,9 @@ class Mutation(graphene.ObjectType):
 
 class Query(graphene.ObjectType):
     protected = graphene.Field(
-        type=ProtectedUnion, message=graphene.String(), token=graphene.String()
+        type=ProtectedUnion,
+        message=graphene.String(),
+        token=graphene.String(),
     )
 
     @query_jwt_required
@@ -104,7 +111,8 @@ class Query(graphene.ObjectType):
 schema = graphene.Schema(query=Query, mutation=Mutation)
 
 app.add_url_rule(
-    "/graphql", view_func=GraphQLView.as_view("graphql", schema=schema, graphiql=True)
+    "/graphql",
+    view_func=GraphQLView.as_view("graphql", schema=schema, graphiql=True),
 )
 
 if __name__ == "__main__":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,9 +13,9 @@ def flask_app():
     app = Flask(__name__)
     auth = GraphQLAuth(app)
 
-    app.config["JWT_SECRET_KEY"] = "something"  # change this!
-    app.config["REFRESH_EXP_LENGTH"] = 30
-    app.config["ACCESS_EXP_LENGTH"] = 10
+    app.config["JWT_SECRET_KEY"] = "something"
+    app.config["JWT_ACCESS_TOKEN_EXPIRES"] = 10
+    app.config["JWT_REFRESH_TOKEN_EXPIRES"] = 30
 
     schema = graphene.Schema(query=Query, mutation=Mutation)
 


### PR DESCRIPTION
Fixes #13 

Also updates README to clarify that `JWT_ACCESS_TOKEN_EXPIRES` and `JWT_REFRESH_TOKEN_EXPIRES` values can be `int` values and how those values are parsed when they are.